### PR TITLE
Update dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ powerspy.py
 
 1. [Required] powerspy.py requires python bluez to communicate using bluetooth with the device. It can be installed on Ubuntu using the following command:
 
-		apt-get install python-bluez
+		apt-get install python-bluez bluez
 
 2. [Optional, recommended] set up your bluetooth device to connect automatically without asking for PIN.
 This can be done by modifying or creating /var/lib/bluetooth/DEVICE/pincodes with the following content: 


### PR DESCRIPTION
On Ubuntu 14.04 LTS the bluez package is not installed by default as dependency of python-bluez (also check http://packages.ubuntu.com/trusty/python-bluez)
